### PR TITLE
Fix bug with using bash in ruby system

### DIFF
--- a/lib/git_helper/clean_git.rb
+++ b/lib/git_helper/clean_git.rb
@@ -4,7 +4,7 @@ module GitHelper
       system("git checkout $(git symbolic-ref refs/remotes/origin/HEAD | sed \"s@^refs/remotes/origin/@@\")")
       system("git pull")
       system("git fetch -p")
-      system("git branch -vv | grep \"origin/.*: gone]\" | awk \"{print \$1}\" | grep -v \"*\" | xargs git branch -D")
+      system("git branch -vv | grep \"origin/.*: gone]\" | awk '{print \$1}' | grep -v \"*\" | xargs git branch -D")
     end
   end
 end

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,3 +1,3 @@
 module GitHelper
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
## Changes

Previously, when running `ghelper clean-git`, we'd see an error where it tried to delete branches that weren't really branches. This resulted in an error. So, after a little debugging, I found this:
```
$ system("git branch -vv | grep \"origin/.*: gone]\" | awk \"{print \$1}\"")
add_place_for_tests_and_run_github_actions 908d707 [origin/add_place_for_tests_and_run_github_actions: gone] Require higher version of rake
```

But it should show just the plain branch name:
```
$ system("git branch -vv | grep \"origin/.*: gone]\" | awk '{print \$1}'")
add_place_for_tests_and_run_github_actions
```

So, update the `clean-git` command to use the new version.