### PR TITLE
GitLab: Sort through paginated branches, not just first page

### DIFF
--- a/lib/git_helper/merge_request.rb
+++ b/lib/git_helper/merge_request.rb
@@ -15,7 +15,7 @@ module GitHelper
         }
 
         puts "Creating merge request: #{new_mr_title}"
-        mr = gitlab_client.create_merge_request(local_repo, new_mr_title, options)
+        mr = gitlab_client.create_merge_request(local_project, new_mr_title, options)
 
         if mr.diff_refs.base_sha == mr.diff_refs.head_sha
           puts "Merge request was created, but no commits have been pushed to GitLab: #{mr.web_url}"
@@ -41,7 +41,7 @@ module GitHelper
         options[:squash_commit_message] = existing_mr_title
 
         puts "Merging merge request: #{mr_id}"
-        merge = gitlab_client.accept_merge_request(local_repo, mr_id, options)
+        merge = gitlab_client.accept_merge_request(local_project, mr_id, options)
         puts "Merge request successfully merged: #{merge.merge_commit_sha}"
       rescue Gitlab::Error::MethodNotAllowed => e
         puts 'Could not merge merge request:'
@@ -55,8 +55,8 @@ module GitHelper
       end
     end
 
-    private def local_repo
-      # Get the repository by looking in the remote URLs for the full repository name
+    private def local_project
+      # Get the project by looking in the remote URLs for the full project name
       remotes = `git remote -v`
       return remotes.scan(/\S[\s]*[\S]+.com[\S]{1}([\S]*).git/).first.first
     end
@@ -81,7 +81,7 @@ module GitHelper
     end
 
     private def existing_mr_title
-      @existing_mr_title ||= gitlab_client.merge_request(local_repo, mr_id).title
+      @existing_mr_title ||= gitlab_client.merge_request(local_project, mr_id).title
     end
 
     private def new_mr_title
@@ -101,7 +101,22 @@ module GitHelper
     end
 
     private def default_branch
-      @default_branch ||= gitlab_client.branches(local_repo).select { |branch| branch.default }.first.name
+      @default_branch ||= all_branches.select { |branch| branch.default }.first.name
+    end
+
+    private def all_branches
+      page_number = 1
+      counter = 1
+      branches = []
+
+      while counter > 0
+        page_branches = gitlab_client.branches(local_project, page: page_number, per_page: 100)
+        branches = branches.concat(page_branches)
+        counter = page_branches.count
+        page_number += 1
+      end
+
+      return branches
     end
 
     private def template_to_apply

--- a/lib/git_helper/merge_request.rb
+++ b/lib/git_helper/merge_request.rb
@@ -101,22 +101,20 @@ module GitHelper
     end
 
     private def default_branch
-      @default_branch ||= all_branches.select { |branch| branch.default }.first.name
-    end
-
-    private def all_branches
+      return @default_branch if @default_branch
       page_number = 1
       counter = 1
       branches = []
 
       while counter > 0
+        break if default_branch = branches.select { |branch| branch.default }.first
         page_branches = gitlab_client.branches(local_project, page: page_number, per_page: 100)
-        branches = branches.concat(page_branches)
+        branches = page_branches
         counter = page_branches.count
         page_number += 1
       end
 
-      return branches
+      @default_branch = default_branch.name
     end
 
     private def template_to_apply

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,3 +1,3 @@
 module GitHelper
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

Previously, the `default_branch` method of the merge_request script assumed that there was only one page of branches per project. Well, that's not an accurate assumption. So, we need to go through each page of branches (yikes... if it's a big project) until we hit the default branch. Then we can stop. So we don't quite need go through _all_ of the pages... just until we find the default branch.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.
