### PR TITLE
Commands should look towards project/repo settings to know which questions to ask

### DIFF
--- a/lib/git_helper/highline_cli.rb
+++ b/lib/git_helper/highline_cli.rb
@@ -43,8 +43,7 @@ module GitHelper
       !!(answer =~ /^y/i)
     end
 
-    def merge_method
-      merge_options = [ 'merge', 'squash', 'rebase' ]
+    def merge_method(merge_options)
       index = ask_options("Merge method?", merge_options)
       merge_options[index]
     end

--- a/lib/git_helper/merge_request.rb
+++ b/lib/git_helper/merge_request.rb
@@ -12,7 +12,7 @@ module GitHelper
         options = {
           source_branch: local_branch,
           target_branch: base_branch,
-          squash_merge_request: true,
+          squash: true,
           remove_source_branch: true,
           description: new_mr_body
         }

--- a/lib/git_helper/merge_request.rb
+++ b/lib/git_helper/merge_request.rb
@@ -12,6 +12,8 @@ module GitHelper
         options = {
           source_branch: local_branch,
           target_branch: base_branch,
+          squash_merge_request: true,
+          remove_source_branch: true,
           description: new_mr_body
         }
 

--- a/lib/git_helper/merge_request.rb
+++ b/lib/git_helper/merge_request.rb
@@ -45,6 +45,12 @@ module GitHelper
 
         puts "Merging merge request: #{mr_id}"
         merge = gitlab_client.accept_merge_request(local_project, mr_id, options)
+
+        if merge.merge_commit_sha.nil?
+          options[:squash] = true
+          merge = gitlab_client.accept_merge_request(local_project, mr_id, options)
+        end
+
         puts "Merge request successfully merged: #{merge.merge_commit_sha}"
       rescue Gitlab::Error::MethodNotAllowed => e
         puts 'Could not merge merge request:'

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,3 +1,3 @@
 module GitHelper
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

### GitHub

Only allow options for merging (merge, squash, rebase) that a repository allows. If they only allow one type of merge, then just use that. Don't give options that won't work.

### GitLab

For branch deletion, look towards the project for guidance. If the project enables branch deletion by default, then set that when creating MRs and don't even ask the user. They can change their mind in the MR manually. If the project doesn't set that as a default, then ask the user whether they'd like to delete the source branch or not _upon MR creation_. When merging an MR, don't ask the user... instead take whatever setting was on the MR.

For squashing, there's no way in the API to see if a project allows squashing or not. This sucks. So ask the user upon MR creation whether to squash or not. When merging, use whatever setting was previously set on the MR.

It's important to note that if the project has specific settings to _require_ or _prevent_ squashing, then the project will ignore what a person says and will just do whatever it should do based on the project's settings.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## QA

### GitHub

- [x] Attempt to merge a PR on a repo that only allows one type of merge... verify it doesn't ask a question about merge method and merge succeeds
- [x] Attempt to merge a PR on a repo that only allows multiple types of merge... verify it asks the merge method question with only the options that the repo allows, and the merge is successful

### GitLab

- [x] Take a project that defaults to deletion of source branch
- [x] Verify creation sets the checkbox to delete automatically
- [x] Take a project that does not default to deletion
- [x] Verify creation asks the user whether to delete the source branch
- [x] Verify the merge of either PR does what's expected (either deletes or doesn't delete the source branch based on the MR's setting)
- [x] Take a project where squashing is prevented
- [x] Verify creation asks the question about squashing, and any answer will be ignored
- [x] Merging that MR will NOT squash
- [x] Take a project where squashing is required
- [x] Verify creation asks the question about squashing, and if the user says 'no', then they'll be overwritten and forced to squash
- [x] Merging that MR will squash
- [x] Take a project where squashing is optional
- [x] Verify creation asks the question about squashing, and the MR comes out with whatever the user says
- [x] Merging that MR will do whatever the MR previously specifies