### PR TITLE
Fix broken empty commit

### DIFF
--- a/lib/git_helper/local_code.rb
+++ b/lib/git_helper/local_code.rb
@@ -10,7 +10,7 @@ module GitHelper
     end
 
     def empty_commit
-      system('git commit --allow-empty -m \"Empty commit\"')
+      system('git commit --allow-empty -m "Empty commit"')
     end
 
     def clean_branches

--- a/lib/git_helper/version.rb
+++ b/lib/git_helper/version.rb
@@ -1,3 +1,3 @@
 module GitHelper
-  VERSION = '3.1.2'
+  VERSION = '3.1.3'
 end


### PR DESCRIPTION
## Changes

Currently, the empty commit command is broken:
```bash
$ git empty-commit
error: pathspec 'commit"' did not match any file(s) known to git
```

At one point it worked, but I think I've moved around so many of the files that it no longer works anymore.

This PR will fix this issue. Basically, we don't need to actually escape the extra bonus quotes... they work anyway.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.
