### PR TITLE
Remove email from gemspec

### DIFF
--- a/git_helper.gemspec
+++ b/git_helper.gemspec
@@ -4,7 +4,6 @@ Gem::Specification.new do |gem|
   gem.name          = 'git_helper'
   gem.version       = GitHelper::VERSION
   gem.authors       = ['Emma Sax']
-  gem.email         = ['emma.sax4@gmail.com']
   gem.summary       = %q{A set of GitHub and GitLab workflow scripts.}
   gem.description   = %q{A set of GitHub and GitLab workflow scripts to provide a smoother development process for your git projects.}
   gem.homepage      = 'https://github.com/emmasax4/git_helper'


### PR DESCRIPTION
## Changes

Remove my email address from the gemspec file. It's not that I don't want people to find my email address... it's not _that_ secretive. However, I'm trying to cut down on the spam emails, so any amount of removing my email address from HTML pages as possible, the better.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.
