### PR TITLE
Use newer ubuntu version in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   default:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Check Out Code
       uses: actions/checkout@v2


### PR DESCRIPTION
## Changes

Make sure that the newest version of GitHub Actions ubuntu OS works on this workflow. Documentation [here](https://github.com/actions/virtual-environments/issues/1816) and [here](https://github.blog/changelog/2020-10-29-github-actions-ubuntu-latest-workflows-will-use-ubuntu-20-04/).

Now that we know that this works, we can close this PR and just wait for that version to become the newest version (called with just `ubuntu-latest`).